### PR TITLE
Remove max-requests to avoid breaking deploy when auto restart

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -17,4 +17,4 @@ export CONSOLE_DB_PASSWORD=$mysql_passwd
 export CONSOLE_SENTRY_DSN=$console_sentry_dsn
 
 mkdir -p /lain/logs
-exec gunicorn -w 3 -b 0.0.0.0:8000 --max-requests=100 --preload --error-logfile /lain/logs/error.log --access-logfile /lain/logs/access.log console.wsgi 
+exec gunicorn -w 3 -b 0.0.0.0:8000 --preload --error-logfile /lain/logs/error.log --access-logfile /lain/logs/access.log console.wsgi 


### PR DESCRIPTION
The deploying is in separate thread. When gunicorn is  auto restarting, the deploying maybe broken by restarting. So sometimes we found some rules of calico profile is not created.

I think the better way is move add calico rule semantics to ensure calico rule exist.